### PR TITLE
docs: fix minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     </h1>
     
   <p align="center">
-        Ocular is an API built onto of Kubernetes that allows you to perform regular or ad-hoc security scans over static software assets.
+        Ocular is an API built on top of Kubernetes that allows you to perform regular or ad-hoc security scans over static software assets.
         It provides a set of RESTful endpoints that allow you to configure and run security or compliance scanning tools.
   </p>
 </div>


### PR DESCRIPTION
Very minor documentation fix `onto of Kubernetes` -> `on top of Kubernetes`. At least I think that is what was meant.