### PR TITLE
feat: v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Ocular Release Notes
+<!-- https://keepachangelog.com -->
+
+# [v0.1.1](https://github.com/crashappsec/ocular/releases/tag/v0.1.1) - **July 16, 2025**
+
+### Added
+
+- Ability to customize Kubernetes annotations for jobs and pods.
+- Support for setting custom labels and annotations in development environment.
+
+### Changed
+
+- Default labels and annotations for jobs and pods.
+  - use domain `ocularproject.io` for all annotations.
 
 # [v0.1.0](https://github.com/crashappsec/ocular/releases/tag/v0.1.0) - **July 15, 2025**
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     </h1>
     
   <p align="center">
-        Ocular is an API built onto of Kubernetes that allows you to perform regular or ad-hoc security scans over static software assets.
+        Ocular is an API built on top of Kubernetes that allows you to perform regular or ad-hoc security scans over static software assets.
         It provides a set of RESTful endpoints that allow you to configure and run security or compliance scanning tools.
   </p>
 </div>

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -100,7 +100,8 @@ type Config struct {
 			// Memory is the memory limit for the container.
 			Memory string `json:"memory" yaml:"memory"`
 		}
-		Labels map[string]string `json:"labels" yaml:"labels" mapstructure:"labels"`
+		Labels      map[string]string `json:"labels" yaml:"labels" mapstructure:"labels"`
+		Annotations map[string]string `json:"annotations" yaml:"annotations" mapstructure:"annotations"`
 		// ImagePullSecrets is a list of image pull secrets that will be attached to
 		// all jobs created by Ocular.
 		ImagePullSecrets []string `json:"imagePullSecrets,omitempty" yaml:"imagePullSecrets,omitempty,flow" mapstructure:"imagePullSecrets"`

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io"
 	"os"
 	"reflect"
@@ -23,6 +22,7 @@ import (
 	"github.com/crashappsec/ocular/pkg/schemas"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 )
 
 // ResourceConfig is the configuration for a resource type in Ocular.
@@ -178,7 +178,10 @@ func Init() {
 
 	// K8s Cluster Access Settings
 	viper.SetDefault("ClusterAccess%Kubeconfig%Path", "~/.kube/config")
-	_ = viper.BindEnv("ClusterAccess%Kubeconfig%Path", "KUBECONFIG") // only errors if no input is given, so can ignore
+	_ = viper.BindEnv(
+		"ClusterAccess%Kubeconfig%Path",
+		"KUBECONFIG",
+	) // only errors if no input is given, so can ignore
 
 	// API Settings
 	viper.SetDefault("API%TLS%Enabled", false)

--- a/pkg/pipelines/run.go
+++ b/pkg/pipelines/run.go
@@ -387,8 +387,9 @@ func buildUploadJob(
 		uploadContainers,
 		append(jobOpts,
 			runtime.JobOptWithLabels(map[string]string{
-				"profile-name": profileName,
-				"pipeline-id":  id.String(),
+				"profile-name":         profileName,
+				"pipeline-id":          id.String(),
+				runtime.LabelExecution: "pipeline",
 			}),
 			runtime.JobOptWithAnnotations(map[string]string{
 				annotationPipelineID:  id.String(),

--- a/pkg/pipelines/types.go
+++ b/pkg/pipelines/types.go
@@ -27,9 +27,9 @@ type Pipeline schemas.Pipeline
 
 /* Annotation Labels */
 const (
-	annotationTargetDownloader = "crashoverride.run/target-downloader"
-	annotationTargetIdentifier = "crashoverride.run/target-identifier"
-	annotationTargetVersion    = "crashoverride.run/target-version"
-	annotationProfileName      = "crashoverride.run/profile-name"
-	annotationPipelineID       = "crashoverride.run/pipeline-id"
+	annotationTargetDownloader = "ocularproject.io/target-downloader"
+	annotationTargetIdentifier = "ocularproject.io/target-identifier"
+	annotationTargetVersion    = "ocularproject.io/target-version"
+	annotationProfileName      = "ocularproject.io/profile-name"
+	annotationPipelineID       = "ocularproject.io/pipeline-id"
 )

--- a/pkg/runtime/jobs.go
+++ b/pkg/runtime/jobs.go
@@ -96,14 +96,17 @@ func BuildJob(
 	}
 
 	jobTTL := config.State.Runtime.JobTTL.Seconds()
+	labels := CreateLabels(map[string]string{
+		LabelResource: resourceName,
+		LabelID:       id.String(),
+	})
+	annotations := CreateAnnotations(nil)
 
 	jobReq := batchV1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: resourceName + "-" + id.String(),
-			Labels: CreateLabels(map[string]string{
-				LabelResource: resourceName,
-				LabelID:       id.String(),
-			}),
+			Name:        resourceName + "-" + id.String(),
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: batchV1.JobSpec{
 			TTLSecondsAfterFinished: ptr.To[int32](int32(jobTTL)), // 3 minutes
@@ -112,10 +115,8 @@ func BuildJob(
 			Completions:             ptr.To[int32](1),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: CreateLabels(map[string]string{
-						LabelResource: resourceName + "-execution",
-						LabelID:       id.String(),
-					}),
+					Labels:      labels,
+					Annotations: annotations,
 				},
 				Spec: v1.PodSpec{
 					RestartPolicy:    "Never",

--- a/pkg/runtime/labels.go
+++ b/pkg/runtime/labels.go
@@ -18,6 +18,11 @@ const (
 	LabelResource = "resource"
 	// LabelID is the label used to identify the resource ID.
 	LabelID = "id"
+	// LabelExecution is the label used to identify the execution type.
+	// either a pipeline or a search
+	LabelExecution = "execution"
+
+	AnnotationVersion = "ocularproject.io/version"
 )
 
 // CreateLabels creates a map of labels for the container.
@@ -43,5 +48,30 @@ func CreateLabels(additional map[string]string) map[string]string {
 	for k, v := range additional {
 		merged[k] = v
 	}
+	return merged
+}
+
+func CreateAnnotations(additional map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for key, val := range config.State.Runtime.Annotations {
+		if len(key) == 0 {
+			continue
+		}
+		if len(key) > 63 {
+			zap.L().Debug("annotation key too long, truncating", zap.String("key", key))
+			key = key[:63]
+		}
+		if len(val) > 63 {
+			zap.L().Debug("annotation value too long, truncating",
+				zap.String("key", key), zap.String("value", val))
+			val = val[:63]
+		}
+		merged[key] = val
+	}
+	for k, v := range additional {
+		merged[k] = v
+	}
+
+	merged[AnnotationVersion] = config.Version
 	return merged
 }

--- a/pkg/searches/run.go
+++ b/pkg/searches/run.go
@@ -32,8 +32,8 @@ import (
 const (
 	labelCrawlerName      = "crawler-name"
 	searchJobType         = "search"
-	annotationCrawlerName = "crashoverride.run/crawler-name"
-	annotationRunID       = "crashoverride.run/search-id"
+	annotationCrawlerName = "ocularproject.io/crawler-name"
+	annotationRunID       = "ocularproject.io/search-id"
 
 	secretVolumeName = "search-secret-volume"
 )
@@ -160,7 +160,8 @@ func buildJob(
 
 	jobOpts := []runtime.JobOpt{
 		runtime.JobOptWithLabels(map[string]string{
-			labelCrawlerName: crawlerName,
+			labelCrawlerName:       crawlerName,
+			runtime.LabelExecution: "search",
 		}),
 		runtime.JobOptWithAnnotations(map[string]string{
 			annotationCrawlerName: crawlerName,


### PR DESCRIPTION
# v0.1.1 - **July 16, 2025**

### Added

- Ability to customize Kubernetes annotations for jobs and pods.
- Support for setting custom labels and annotations in development environment.

### Changed

- Default labels and annotations for jobs and pods.
  - use domain `ocularproject.io` for all annotations.
