### PR TITLE
feat: add runtime class support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,12 +206,12 @@ gha-upgrade: ratchet ## upgrades all pinned github actions used in any workflows
 ##@ Build
 
 .PHONY: build
-build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/manager/main.go
+build: manifests generate fmt vet ## Build controller binary.
+	go build -o bin/controller cmd/controller/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/manager/main.go
+	go run ./cmd/controller/main.go
 
 .PHONY: docker-build-all
 docker-build-all: docker-build-controller docker-build-sidecar ## Builds all docker images

--- a/api/v1beta1/pipeline_types.go
+++ b/api/v1beta1/pipeline_types.go
@@ -62,6 +62,11 @@ type PipelineSpec struct {
 	// +optional
 	UploadServiceAccountName string `json:"uploadServiceAccountName,omitempty" protobuf:"bytes,5,opt,name=uploadServiceAccountName" description:"The name of the service account that will be used to run the upload job."`
 
+	// RuntimeClassName is the name of the RuntimeClass that will be used to run the scan and upload pods.
+	// If not set, the cluster's default runtime handler will be used.
+	// +optional
+	RuntimeClassName *string `json:"runtimeClassName,omitempty" protobuf:"bytes,8,opt,name=runtimeClassName" description:"The name of the RuntimeClass that will be used to run the scan and upload pods."`
+
 	// TTLSecondsAfterFinished
 	// If set, the pipeline and its associated resources will be automatically deleted
 	// after the specified number of seconds have passed since the pipeline finished.

--- a/api/v1beta1/search_types.go
+++ b/api/v1beta1/search_types.go
@@ -60,6 +60,11 @@ type SearchSpec struct {
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty" protobuf:"bytes,4,opt,name=serviceAccountName" description:"The name of the service account that will be used to run the search job."`
 
+	// RuntimeClassName is the name of the RuntimeClass that will be used to run the search pod.
+	// If not set, the cluster's default runtime handler will be used.
+	// +optional
+	RuntimeClassName *string `json:"runtimeClassName,omitempty" protobuf:"bytes,5,opt,name=runtimeClassName" description:"The name of the RuntimeClass that will be used to run the search pod."`
+
 	// Scheduler represents the configuration of the scheduler sidecar
 	// +optional
 	Scheduler SearchSchedulerSpec `json:"scheduler,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -780,6 +780,11 @@ func (in *PipelineSpec) DeepCopyInto(out *PipelineSpec) {
 	in.DownloaderRef.DeepCopyInto(&out.DownloaderRef)
 	in.ProfileRef.DeepCopyInto(&out.ProfileRef)
 	out.Target = in.Target
+	if in.RuntimeClassName != nil {
+		in, out := &in.RuntimeClassName, &out.RuntimeClassName
+		*out = new(string)
+		**out = **in
+	}
 	if in.TTLSecondsAfterFinished != nil {
 		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished
 		*out = new(int32)
@@ -1093,6 +1098,11 @@ func (in *SearchSpec) DeepCopyInto(out *SearchSpec) {
 	if in.TTLSecondsAfterFinished != nil {
 		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished
 		*out = new(int32)
+		**out = **in
+	}
+	if in.RuntimeClassName != nil {
+		in, out := &in.RuntimeClassName, &out.RuntimeClassName
+		*out = new(string)
 		**out = **in
 	}
 	in.Scheduler.DeepCopyInto(&out.Scheduler)

--- a/config/crd/bases/ocular.crashoverride.run_cronsearches.yaml
+++ b/config/crd/bases/ocular.crashoverride.run_cronsearches.yaml
@@ -111,6 +111,11 @@ spec:
                         required:
                         - name
                         type: object
+                      runtimeClassName:
+                        description: |-
+                          RuntimeClassName is the name of the RuntimeClass that will be used to run the search pod.
+                          If not set, the cluster's default runtime handler will be used.
+                        type: string
                       scheduler:
                         description: Scheduler represents the configuration of the
                           scheduler sidecar
@@ -251,6 +256,11 @@ spec:
                                     required:
                                     - name
                                     type: object
+                                  runtimeClassName:
+                                    description: |-
+                                      RuntimeClassName is the name of the RuntimeClass that will be used to run the scan and upload pods.
+                                      If not set, the cluster's default runtime handler will be used.
+                                    type: string
                                   scanServiceAccountName:
                                     description: |-
                                       ScanServiceAccountName is the name of the service account that will be used to run the scan job.

--- a/config/crd/bases/ocular.crashoverride.run_pipelines.yaml
+++ b/config/crd/bases/ocular.crashoverride.run_pipelines.yaml
@@ -141,6 +141,11 @@ spec:
                 required:
                 - name
                 type: object
+              runtimeClassName:
+                description: |-
+                  RuntimeClassName is the name of the RuntimeClass that will be used to run the scan and upload pods.
+                  If not set, the cluster's default runtime handler will be used.
+                type: string
               scanServiceAccountName:
                 description: |-
                   ScanServiceAccountName is the name of the service account that will be used to run the scan job.

--- a/config/crd/bases/ocular.crashoverride.run_searches.yaml
+++ b/config/crd/bases/ocular.crashoverride.run_searches.yaml
@@ -73,6 +73,11 @@ spec:
                 required:
                 - name
                 type: object
+              runtimeClassName:
+                description: |-
+                  RuntimeClassName is the name of the RuntimeClass that will be used to run the search pod.
+                  If not set, the cluster's default runtime handler will be used.
+                type: string
               scheduler:
                 description: Scheduler represents the configuration of the scheduler
                   sidecar
@@ -209,6 +214,11 @@ spec:
                             required:
                             - name
                             type: object
+                          runtimeClassName:
+                            description: |-
+                              RuntimeClassName is the name of the RuntimeClass that will be used to run the scan and upload pods.
+                              If not set, the cluster's default runtime handler will be used.
+                            type: string
                           scanServiceAccountName:
                             description: |-
                               ScanServiceAccountName is the name of the service account that will be used to run the scan job.

--- a/internal/controller/pipeline_controller.go
+++ b/internal/controller/pipeline_controller.go
@@ -576,6 +576,7 @@ func (r *PipelineReconciler) populateUploadPod(pod *corev1.Pod, pipeline *v1beta
 			},
 		}
 		pod.Spec.ServiceAccountName = pipeline.Spec.UploadServiceAccountName
+		pod.Spec.RuntimeClassName = pipeline.Spec.RuntimeClassName
 		pod.Spec.RestartPolicy = corev1.RestartPolicyNever
 		pod.Spec.Containers = containers.ApplyOptions(uploaderContainers, containerOpts...)
 		pod.Spec.InitContainers = containers.ApplyOptions([]corev1.Container{
@@ -630,6 +631,7 @@ func (r *PipelineReconciler) populateScanPod(pod *corev1.Pod, pipeline *v1beta1.
 		scannerContainers := containers.FilterConditionalContainers(profile.Spec.Containers, pipeline.Spec.ProfileRef.Parameters)
 
 		pod.Spec.ServiceAccountName = pipeline.Spec.ScanServiceAccountName
+		pod.Spec.RuntimeClassName = pipeline.Spec.RuntimeClassName
 		pod.Spec.RestartPolicy = corev1.RestartPolicyNever
 		pod.Spec.Containers = containers.ApplyOptions(scannerContainers, append(containerOpts,
 			containers.WithParameters(profile.Spec.Parameters, pipeline.Spec.ProfileRef.Parameters))...,

--- a/internal/controller/pipeline_controller_test.go
+++ b/internal/controller/pipeline_controller_test.go
@@ -27,9 +27,10 @@ import (
 var _ = Describe("Pipeline Controller", func() {
 	rnd := rand.New(rand.NewSource(GinkgoRandomSeed()))
 	var (
-		namespace    = "default"
-		sidecarImage = testutils.GenerateRandomString(rnd, 10, testutils.LowercaseAlphabeticLetterSet) + ":latest"
-		downloader   *v1beta1.Downloader
+		namespace        = "default"
+		runtimeClassName = "kata"
+		sidecarImage     = testutils.GenerateRandomString(rnd, 10, testutils.LowercaseAlphabeticLetterSet) + ":latest"
+		downloader       *v1beta1.Downloader
 	)
 	BeforeEach(func() {
 		downloader = &v1beta1.Downloader{
@@ -137,6 +138,7 @@ var _ = Describe("Pipeline Controller", func() {
 						Identifier: "https://example.com/samplefile.txt",
 					},
 					ScanServiceAccountName: testutils.GenerateRandomString(rnd, 10, testutils.LowercaseAlphabeticLetterSet),
+					RuntimeClassName:       &runtimeClassName,
 				},
 			}
 			Expect(k8sClient.Create(ctx, profileResource)).To(Succeed())
@@ -314,6 +316,7 @@ var _ = Describe("Pipeline Controller", func() {
 					},
 					ScanServiceAccountName:   testutils.GenerateRandomString(rnd, 10, testutils.LowercaseAlphabeticLetterSet),
 					UploadServiceAccountName: testutils.GenerateRandomString(rnd, 10, testutils.LowercaseAlphabeticLetterSet),
+					RuntimeClassName:         &runtimeClassName,
 				},
 			}
 			Expect(k8sClient.Create(ctx, uploader)).To(Succeed())
@@ -437,6 +440,7 @@ func ValidatePipelineScanPodSpec(podSpec corev1.PodSpec,
 	Expect(*podSpec.InitContainers[1].RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways)) // is a sidecar
 
 	Expect(podSpec.ServiceAccountName).To(Equal(pipeline.Spec.ScanServiceAccountName))
+	Expect(podSpec.RuntimeClassName).To(Equal(pipeline.Spec.RuntimeClassName))
 	for _, container := range podSpec.Containers {
 		Expect(container.Env).To(ContainElements(
 			corev1.EnvVar{
@@ -492,6 +496,7 @@ func ValidatePipelineUploadPodSpec(podSpec corev1.PodSpec,
 	Expect(podSpec.InitContainers[0].Args).Should(HaveLen(len(profile.Spec.Artifacts) + 2))
 
 	Expect(podSpec.ServiceAccountName).To(Equal(pipeline.Spec.UploadServiceAccountName))
+	Expect(podSpec.RuntimeClassName).To(Equal(pipeline.Spec.RuntimeClassName))
 	for _, container := range podSpec.Containers {
 		Expect(container.Args).Should(HaveLen(len(profile.Spec.Artifacts) + 2))
 		Expect(container.Env).To(ContainElements(

--- a/internal/controller/search_controller.go
+++ b/internal/controller/search_controller.go
@@ -317,6 +317,7 @@ func (r *SearchReconciler) populateSearchPod(search *v1beta1.Search, pod *corev1
 		}
 
 		pod.Spec.ServiceAccountName = search.Spec.ServiceAccountName
+		pod.Spec.RuntimeClassName = search.Spec.RuntimeClassName
 		pod.Spec.RestartPolicy = corev1.RestartPolicyNever
 		pod.Spec.InitContainers = containers.ApplyOptions([]corev1.Container{
 			// 1. we start the side car scheduler

--- a/internal/controller/search_controller_test.go
+++ b/internal/controller/search_controller_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Search Controller", func() {
 			crawlerContainerName = "crawler-container"
 			searchClusterRole    = "test-search-cluster-role"
 		)
+		runtimeClassName := "kata"
 
 		ctx := context.Background()
 
@@ -120,6 +121,7 @@ var _ = Describe("Search Controller", func() {
 					},
 					Spec: v1beta1.SearchSpec{
 						ServiceAccountName: serviceAccountName,
+						RuntimeClassName:   &runtimeClassName,
 						CrawlerRef: v1beta1.ParameterizedLocalObjectReference{
 							Name: crawlerName,
 							Parameters: []v1beta1.ParameterSetting{
@@ -216,6 +218,7 @@ var _ = Describe("Search Controller", func() {
 			// check containers
 			Expect(searchPod.Spec.Containers).To(HaveLen(1)) // sidecar-keepalive
 			Expect(searchPod.Spec.Containers[0].Name).To(Equal(sidecarKeepaliveContainerName))
+			Expect(searchPod.Spec.RuntimeClassName).To(Equal(search.Spec.RuntimeClassName))
 
 			// check annotations
 			templateJSON, err := json.Marshal(search.Spec.Scheduler.PipelineTemplate)

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -18,6 +18,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	nodev1 "k8s.io/api/node/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,6 +56,8 @@ var _ = BeforeSuite(func() {
 	var err error
 	err = ocularcrashoverriderunv1beta1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
+	err = nodev1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
@@ -76,6 +80,12 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	err = k8sClient.Create(ctx, &nodev1.RuntimeClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "kata"},
+		Handler:    "kata",
+	})
+	Expect(err).NotTo(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
## Summary
- add optional spec.runtimeClassName to Pipelines and Searches
- propagate runtimeClassName to generated scan, upload, and search Pods
- regenerate CRDs/deepcopy and cover the new Pod fields in controller tests
- fix the stale Makefile build/run path from cmd/manager to cmd/controller

## Verification
- make test
- make build
- GOCACHE=/tmp/ocular-go-build go build ./...